### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auth-sync-app-ci.yml
+++ b/.github/workflows/auth-sync-app-ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "test"


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/nr-auth-sync-app/security/code-scanning/1](https://github.com/bcgov/nr-auth-sync-app/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/auth-sync-app-ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this pipeline, the minimal safe permission is:

- `contents: read`

This supports `actions/checkout` while preventing unnecessary write scopes. No imports, methods, or additional definitions are needed—just YAML configuration in this file near the `on:`/`jobs:` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
